### PR TITLE
setPreviewCard, setPreviewCardByData에서 act값 중복요청 방지

### DIFF
--- a/tpl/js/services/_functions.js
+++ b/tpl/js/services/_functions.js
@@ -112,7 +112,7 @@ export async function setPreviewCard(obj) {
 		layout: 'none'
 	};
 
-	$.get(current_url, params, function(result) {
+	$.get(current_url.setQuery('act', null), params, function(result) {
 		arrangePreviewResult(obj, result);
 	});
 }
@@ -132,7 +132,7 @@ export async function setPreviewCardByData(obj) {
 		layout: 'none'
 	};
 
-	$.get(current_url, params, function(result) {
+	$.get(current_url.setQuery('act', null), params, function(result) {
 		arrangePreviewResult(obj, result);
 	});
 }


### PR DESCRIPTION
current_url로만 요청하면 act값이 dispBoardWrite가 함께 붙는 관련 문제를 해결했습니다.

관련하여 URL query에서 좀더 붙으면 아예 `new URL(current_url).origin` 로 대체하는것도 방법중 하나입니다.