### PR TITLE
Twitter(X) embed가 제대로 작동하지 않는 문제 해결

### DIFF
--- a/tpl/css/media_embed.css
+++ b/tpl/css/media_embed.css
@@ -394,6 +394,11 @@
 	display: inline-block; width: 550px; max-width: 100%; height: auto;
     padding-bottom: 10px; border-bottom: 1px solid #c4cfd6; text-align: left;
 }
+.media_embed.twitter-status > iframe,
+.media_embed.twitter-list > iframe,
+.media_embed.twitter-profile > iframe {
+	position:inherit;
+}
 .media_embed.twitter-status {
 	border-bottom: none;
 }


### PR DESCRIPTION
관리자의 경우 inline style에서 position:static이 유지되며 문제가 없지만, 회원이 첨부할 경우 position 관련 지정이 HTMLPurifier에 의해 사라지면서 embed가 제대로 표현되지 않는 문제가 존재했습니다.

그것과 관련한 해결을 위한 PR입니다.